### PR TITLE
Adding tls files to .gitignore

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 c-lightning.sock
 config.json
+tls.cert
+tls.key


### PR DESCRIPTION
When running the server, it generates 2 files automatically for the `tls`, it is handy to have them in .gitignore so they don't get in a commit by mistake.