### PR TITLE
feat: add tftRotation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ The following is a list of possible configuration options for your Bleskomat (DI
 	* 0.50 EUR = 10 pulses
 	* 1.00 EUR = 20 pulses
 	* 2.00 EUR = 40 pulses
+* `tftRotation` The orientation of the TFT display. This is useful to allow different positions of the display. The possible rotation values are:
+	* 0 = 0 degrees
+	* 1 = 90 degrees
+	* 2 = 180 degrees
+	* 3 = 270 degrees
+
 
 It is possible to configure your Bleskomat via the following methods:
 * [Hard-coded configuration](#hard-coded-configuration)
@@ -328,6 +334,7 @@ uriSchemaPrefix=
 fiatCurrency=EUR
 fiatPrecision=2
 coinValueIncrement=0.05
+tftRotation=2
 ```
 
 

--- a/include/config.h
+++ b/include/config.h
@@ -35,6 +35,7 @@ struct BleskomatConfig {
 	std::string uriSchemaPrefix = "LIGHTNING";
 	std::string fiatCurrency = "EUR";
 	unsigned short fiatPrecision = 2;
+	unsigned short tftRotation = 2;
 	float coinValueIncrement;
 };
 
@@ -44,6 +45,7 @@ namespace config {
 	std::string get(const char* &t_key);
 	std::string get(const std::string &key);
 	unsigned short getFiatPrecision();
+	unsigned short getTftRotation();
 	float getCoinValueIncrement();
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -34,7 +34,8 @@ namespace {
 		"uriSchemaPrefix",
 		"fiatCurrency",
 		"fiatPrecision",
-		"coinValueIncrement"
+		"coinValueIncrement",
+		"tftRotation"
 	};
 
 	bool setConfigValue(const std::string &key, const std::string &value, BleskomatConfig &t_values) {
@@ -58,6 +59,9 @@ namespace {
 		} else if (key == "coinValueIncrement") {
 			// Convert string to float:
 			t_values.coinValueIncrement = std::atof(value.c_str());
+		} else if (key == "tftRotation") {
+			// Convert string to short:
+			t_values.tftRotation = (char)( *value.c_str() - '0' );;
 		} else {
 			return false;
 		}
@@ -83,6 +87,8 @@ namespace {
 			return std::to_string(t_values.fiatPrecision);
 		} else if (key == "coinValueIncrement") {
 			return std::to_string(t_values.coinValueIncrement);
+		} else if (key == "tftRotation") {
+			return std::to_string(t_values.tftRotation);
 		}
 		return "";
 	}
@@ -162,6 +168,7 @@ namespace config {
 		// values.fiatCurrency = "EUR";
 		// values.fiatPrecision = 2;
 		// values.coinValueIncrement = 0.05;
+		// values.tftRotation = 2;
 		printConfig(values);
 	}
 
@@ -180,6 +187,10 @@ namespace config {
 
 	unsigned short getFiatPrecision() {
 		return values.fiatPrecision;
+	}
+
+	unsigned short getTftRotation() {
+		return values.tftRotation;
 	}
 
 	float getCoinValueIncrement() {

--- a/src/modules/tft.cpp
+++ b/src/modules/tft.cpp
@@ -137,6 +137,7 @@ namespace tft {
 	void init() {
 		logger::write("tft.init");
 		display.begin();
+		display.setRotation(config::getTftRotation());
 		clearScreen();
 	}
 


### PR DESCRIPTION
This PR adds a new configuration parameter `tftRotation` to allow rotating the display to allow different position of the TFT display.