### PR TITLE
feat: make type of coin acceptor a build flag

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -36,6 +36,7 @@ struct BleskomatConfig {
 	std::string fiatCurrency = "EUR";
 	unsigned short fiatPrecision = 2;
 	std::vector<float> coinValues;
+	float coinValueIncrement;
 };
 
 namespace config {
@@ -45,6 +46,7 @@ namespace config {
 	std::string get(const std::string &key);
 	unsigned short getFiatPrecision();
 	std::vector<float> getCoinValues();
+	float getCoinValueIncrement();
 }
 
 #endif

--- a/include/modules/dg600f.h
+++ b/include/modules/dg600f.h
@@ -15,8 +15,8 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef BLESKOMAT_MODULES_COIN_ACCEPTOR_H
-#define BLESKOMAT_MODULES_COIN_ACCEPTOR_H
+#ifndef BLESKOMAT_MODULES_DG600F_H
+#define BLESKOMAT_MODULES_DG600F_H
 
 #include "config.h"
 #include "logger.h"
@@ -38,7 +38,7 @@
 	#define COIN_ACCEPTOR_BAUDRATE 9600
 #endif
 
-namespace coinAcceptor {
+namespace dg600f {
 	void init();
 	void loop();
 	float getAccumulatedValue();

--- a/include/modules/hx616.h
+++ b/include/modules/hx616.h
@@ -15,34 +15,26 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef BLESKOMAT_MODULES_H
-#define BLESKOMAT_MODULES_H
+#ifndef BLESKOMAT_MODULES_HX616_H
+#define BLESKOMAT_MODULES_HX616_H
 
 #include "config.h"
 #include "logger.h"
+#include <Arduino.h>
 
-#ifdef DG600F
-	#include "modules/dg600f.h"
-	namespace coinAcceptor = dg600f;
-#elif HX616
-	#include "modules/hx616.h"
-	namespace coinAcceptor = hx616;
+#ifndef COIN_ACCEPTOR_SIGNAL
+	#define COIN_ACCEPTOR_SIGNAL 3
 #endif
 
-#ifdef BUTTON
-	#include "modules/button.h"
-#endif
-
-#ifdef TFT
-	#include "modules/tft.h"
-	namespace screen = tft;
-#else
-	#include "modules/dummy/screen.h"
-#endif
-
-namespace modules {
+namespace hx616 {
 	void init();
 	void loop();
+	float getAccumulatedValue();
+	void reset();
+	bool isOff();
+	bool isOn();
+	void on();
+	void off();
 }
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,19 +14,20 @@ src_dir = src
 include_dir = include
 
 [button_module]
-build_flags = 
+build_flags =
 	-D BUTTON
 	-D BUTTON_PIN=33
 
 [coin_acceptor]
-build_flags = 
+build_flags =
 	-D COIN_ACCEPTOR
+	-D DG600F
 	-D COIN_ACCEPTOR_SIGNAL=3
 	-D COIN_ACCEPTOR_INHIBIT=1
 	-D COIN_ACCEPTOR_BAUDRATE=9600
 
 [sd_module]
-build_flags = 
+build_flags =
 	-D USE_SPI_MODE
 	-D SD_CS=15
 	-D SD_MOSI=13
@@ -34,7 +35,7 @@ build_flags =
 	-D SD_SCK=14
 
 [tft_module]
-build_flags = 
+build_flags =
 	-D TFT
 	-D TFT_WIDTH=128
 	-D TFT_HEIGHT=160
@@ -58,7 +59,7 @@ build_flags = !echo "'-D FIRMWARE_COMMIT_HASH=\"$(git rev-parse HEAD)\"'"
 platform = espressif32
 board = esp32dev
 framework = arduino
-build_flags = 
+build_flags =
 	${button_module.build_flags}
 	${coin_acceptor.build_flags}
 	${firmware.build_flags}
@@ -70,7 +71,7 @@ build_flags =
 	; The following flags are needed for std::stoi, std::to_string, etc:
 	-D _GLIBCXX_USE_C99 -std=c++11
 monitor_speed = 115200
-lib_deps = 
+lib_deps =
 	https://github.com/chill117/QRCode.git#v0.0.2
 	TFT_eSPI@^2.2.6
 	chill1/lnurl@0.4.0

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -165,10 +165,8 @@ namespace config {
 		// values.uriSchemaPrefix = "";
 		// values.fiatCurrency = "EUR";
 		// values.fiatPrecision = 2;
-		// // coin acceptor DG600F
-		// values.coinValues = { 0.05, 0.10, 0.20, 0.50, 1.00, 2.00 };
-		// // coin acceptor hx616
-		// values.coinValueIncrement = 0.05;
+		// values.coinValues = { 0.05, 0.10, 0.20, 0.50, 1.00, 2.00 };// DG600F
+		// values.coinValueIncrement = 0.05;// HX616
 		printConfig(values);
 	}
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -33,7 +33,8 @@ namespace {
 		"uriSchemaPrefix",
 		"fiatCurrency",
 		"fiatPrecision",
-		"coinValues"
+		"coinValues",
+		"coinValueIncrement",
 	};
 
 	bool setConfigValue(const std::string &key, const std::string &value, BleskomatConfig &t_values) {
@@ -56,7 +57,10 @@ namespace {
 			t_values.fiatPrecision = (char)( *value.c_str() - '0' );
 		} else if (key == "coinValues") {
 			t_values.coinValues = util::stringListToFloatVector(value);
-		} else {
+		} else if (key == "coinValueIncrement") {
+			// Convert string to float:
+			t_values.coinValueIncrement = std::atof(value.c_str());
+		}  else {
 			return false;
 		}
 		return true;
@@ -81,6 +85,8 @@ namespace {
 			return std::to_string(t_values.fiatPrecision);
 		} else if (key == "coinValues") {
 			return util::floatVectorToStringList(t_values.coinValues);
+		} else if (key == "coinValueIncrement") {
+			return std::to_string(t_values.coinValueIncrement);
 		}
 		return "";
 	}
@@ -159,7 +165,10 @@ namespace config {
 		// values.uriSchemaPrefix = "";
 		// values.fiatCurrency = "EUR";
 		// values.fiatPrecision = 2;
+		// // coin acceptor DG600F
 		// values.coinValues = { 0.05, 0.10, 0.20, 0.50, 1.00, 2.00 };
+		// // coin acceptor hx616
+		// values.coinValueIncrement = 0.05;
 		printConfig(values);
 	}
 
@@ -182,5 +191,9 @@ namespace config {
 
 	std::vector<float> getCoinValues() {
 		return values.coinValues;
+	}
+
+	float getCoinValueIncrement() {
+		return values.coinValueIncrement;
 	}
 }

--- a/src/modules/dg600f.cpp
+++ b/src/modules/dg600f.cpp
@@ -15,7 +15,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "modules/coin-acceptor.h"
+#include "modules/dg600f.h"
 
 namespace {
 
@@ -69,14 +69,14 @@ namespace {
 	}
 }
 
-namespace coinAcceptor {
+namespace dg600f {
 
 	void init() {
 		coinValues = config::getCoinValues();
 		maxCoinValue = findMaxValueInFloatVector(coinValues);
 		Serial2.begin(COIN_ACCEPTOR_BAUDRATE, SERIAL_8N1, COIN_ACCEPTOR_SIGNAL, 0);
 		pinMode(COIN_ACCEPTOR_INHIBIT, OUTPUT);
-		coinAcceptor::on();
+		dg600f::on();
 	}
 
 	void loop() {

--- a/src/modules/hx616.cpp
+++ b/src/modules/hx616.cpp
@@ -1,0 +1,90 @@
+/*
+	Copyright (C) 2020 Samotari (Charles Hill, Carlos Garcia Ortiz)
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "modules/hx616.h"
+
+namespace {
+
+	bool inhibited = false;
+	float valueIncrement = 1.00;
+	float accumulatedValue = 0.00;
+	uint8_t lastPinReadState;
+	unsigned long lastPinReadTime = 0;
+
+	bool coinWasInserted() {
+		unsigned long diffTime = millis() - lastPinReadTime;
+		return lastPinReadState == LOW && diffTime > 25 && diffTime < 35;
+	}
+
+	void flipPinState() {
+		// Flip the state of the last read.
+		lastPinReadState = lastPinReadState == HIGH ? LOW : HIGH;
+		lastPinReadTime = millis();
+	}
+
+	uint8_t readPin() {
+		return digitalRead(COIN_ACCEPTOR_SIGNAL);
+	}
+
+	bool pinStateHasChanged() {
+		return readPin() != lastPinReadState;
+	}
+}
+
+namespace hx616 {
+
+	void init() {
+		pinMode(COIN_ACCEPTOR_SIGNAL, INPUT_PULLUP);
+		lastPinReadState = readPin();
+		valueIncrement = config::getCoinValueIncrement();
+	}
+
+	void loop() {
+		if (pinStateHasChanged()) {
+			if (coinWasInserted()) {
+				// This code executes once for each pulse from the HX-616.
+				logger::write("Coin inserted");
+				accumulatedValue += valueIncrement;
+			}
+			flipPinState();
+		}
+	}
+
+	float getAccumulatedValue() {
+		return accumulatedValue;
+	}
+
+	void reset() {
+		accumulatedValue = 0.00;
+	}
+
+	bool isOff() {
+		return inhibited;
+	}
+
+	bool isOn() {
+		return !inhibited;
+	}
+
+	void on() {
+		// Not implemented for the HX-616.
+	}
+
+	void off() {
+		// Not implemented for the HX-616.
+	}
+}


### PR DESCRIPTION
Making possible to have the 2 different coin-acceptors in the same branch, using a build flag to decide which one.