### PR TITLE
JSON-RPC via serial

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -21,6 +21,7 @@
 #include "sdcard.h"
 #include "util.h"
 
+#include <ArduinoJson.h>
 #include <lnurl.h>
 #include <Preferences.h>
 
@@ -32,7 +33,7 @@
 
 struct BleskomatConfig {
 	struct Lnurl::SignerConfig lnurl;
-	std::string uriSchemaPrefix = "LIGHTNING";
+	std::string uriSchemaPrefix = "LIGHTNING:";
 	std::string fiatCurrency = "EUR";
 	unsigned short fiatPrecision = 2;
 	std::vector<float> coinValues;
@@ -49,6 +50,8 @@ namespace config {
 	std::vector<float> getCoinValues();
 	float getCoinValueIncrement();
 	unsigned short getTftRotation();
+	JsonObject getConfigurations();
+	bool saveConfigurations(const JsonObject &configurations);
 }
 
 #endif

--- a/include/json-rpc.h
+++ b/include/json-rpc.h
@@ -15,37 +15,19 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef BLESKOMAT_MAIN_H
-#define BLESKOMAT_MAIN_H
+#ifndef BLESKOMAT_JSON_RPC_H
+#define BLESKOMAT_JSON_RPC_H
 
 #include "config.h"
-#include "json-rpc.h"
 #include "logger.h"
-#include "modules.h"
-#include "util.h"
+#include "main.h"
 
-#include <lnurl.h>
+#include <ArduinoJson.h>
 #include <string>
 
-#define STRINGIFY(s) STRINGIFY1(s)
-#define STRINGIFY1(s) #s
-
-#ifndef FIRMWARE_COMMIT_HASH
-	#error "Missing required build flag: FIRMWARE_COMMIT_HASH"
-#endif
-
-#ifndef FIRMWARE_VERSION
-	#error "Missing required build flag: FIRMWARE_VERSION"
-#endif
-
-namespace {
-	std::string trimQuotes(const std::string &str) {
-		return str.substr(1, str.length() - 2);
-	}
+namespace jsonRpc {
+	void loop();
+	bool inUse();
 }
-
-const std::string firmwareName = "Bleskomat DIY";
-const std::string firmwareCommitHash(trimQuotes(STRINGIFY(FIRMWARE_COMMIT_HASH)));
-const std::string firmwareVersion(trimQuotes(STRINGIFY(FIRMWARE_VERSION)));
 
 #endif

--- a/include/logger.h
+++ b/include/logger.h
@@ -22,7 +22,8 @@
 #include <string>
 
 namespace logger {
-	void write(const std::string &msg);
+	void write(const std::string &t_msg, const std::string &t_type);
+	void write(const std::string &t_msg);
 }
 
 #endif

--- a/include/sdcard.h
+++ b/include/sdcard.h
@@ -35,6 +35,7 @@
 namespace sdcard {
 	bool isMounted();
 	std::string getMountPoint();
+	std::string getMountedPath(const std::string &partialPath);
 	void init();
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,8 @@ build_flags =
 [coin_acceptor]
 build_flags =
 	-D COIN_ACCEPTOR
-	-D DG600F
+	;-D DG600F
+	-D HX616
 	-D COIN_ACCEPTOR_SIGNAL=3
 	-D COIN_ACCEPTOR_INHIBIT=1
 	-D COIN_ACCEPTOR_BAUDRATE=9600
@@ -53,12 +54,17 @@ build_flags =
 ; Use single quotes around whole build flag definition + double-quotes around value.
 ; Each build flag should be printed on its own line.
 [firmware]
-build_flags = !echo "'-D FIRMWARE_COMMIT_HASH=\"$(git rev-parse HEAD)\"'"
+build_flags =
+	!echo "'-D FIRMWARE_COMMIT_HASH=\"$(git rev-parse HEAD)\"'"
+	'-D FIRMWARE_VERSION="v1.1.0"'
 
 [env:bleskomat32]
 platform = espressif32
 board = esp32dev
 framework = arduino
+upload_speed = 921600
+; https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html
+board_build.partitions = no_ota.csv
 build_flags =
 	${button_module.build_flags}
 	${coin_acceptor.build_flags}
@@ -73,5 +79,6 @@ build_flags =
 monitor_speed = 115200
 lib_deps =
 	https://github.com/chill117/QRCode.git#v0.0.2
-	TFT_eSPI@^2.2.6
-	chill1/lnurl@0.4.0
+	TFT_eSPI@2.4.61
+	chill1/lnurl@0.4.1
+	bblanchon/ArduinoJson@6.19.4

--- a/src/json-rpc.cpp
+++ b/src/json-rpc.cpp
@@ -1,0 +1,137 @@
+/*
+	Copyright (C) 2020 Samotari (Charles Hill, Carlos Garcia Ortiz)
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "json-rpc.h"
+
+namespace {
+
+	uint32_t bootTime = micros();
+	uint32_t maxInitialMessageWaitTime = 2000000;// microseconds
+	bool sentWaitingMessage = false;
+	bool receivedMessage = false;
+	bool timedOut = false;
+
+	// https://arduinojson.org/
+	// https://www.jsonrpc.org/specification
+	const std::string jsonRpcVersion = "2.0";
+
+	void onMessage(const std::string &message) {
+		try {
+			if (message != "" && message.substr(0, 1) == "{") {
+				// !! Important !!
+				// Keep the JsonDocument instance until done reading from the deserialized document; more info:
+				// https://arduinojson.org/v6/issues/garbage-out/
+				DynamicJsonDocument docIn(1024);
+				const DeserializationError err = deserializeJson(docIn, message);
+				if (err) {
+					throw std::runtime_error("deserializeJson failed: " + std::string(err.c_str()));
+				}
+				const JsonObject json = docIn.as<JsonObject>();
+				const std::string jsonrpc = json["jsonrpc"].as<const char*>();
+				if (jsonrpc != "2.0") {
+					throw std::runtime_error("Unknown JSON-RPC version: \"" + jsonrpc + "\"");
+				}
+				if (!receivedMessage) {
+					logger::write("JSON-RPC serial interface active");
+					receivedMessage = true;
+				}
+				const std::string id = json["id"].as<const char*>();
+				const std::string method = json["method"].as<const char*>();
+				if (method == "") {
+					DynamicJsonDocument docOut(256);
+					docOut["jsonrpc"] = jsonRpcVersion;
+					docOut["id"] = id;
+					docOut["error"] = "\"method\" is required";
+					serializeJson(docOut, Serial);
+					Serial.println();
+				} else if (method == "restart") {
+					esp_restart();
+				} else if (method == "echo") {
+					const std::string text = json["params"][0].as<const char*>();
+					DynamicJsonDocument docOut(256);
+					docOut["jsonrpc"] = jsonRpcVersion;
+					docOut["id"] = id;
+					docOut["result"] = text;
+					serializeJson(docOut, Serial);
+					Serial.println();
+				} else if (method == "getinfo") {
+					DynamicJsonDocument docOut(512);
+					docOut["jsonrpc"] = jsonRpcVersion;
+					docOut["id"] = id;
+					DynamicJsonDocument docInfo(384);
+					docInfo["firmwareName"] = firmwareName;
+					docInfo["firmwareCommitHash"] = firmwareCommitHash;
+					docInfo["firmwareVersion"] = firmwareVersion;
+					docOut["result"] = docInfo;
+					serializeJson(docOut, Serial);
+					Serial.println();
+				} else if (method == "getconfig") {
+					DynamicJsonDocument docOut(4096);
+					const JsonObject configurations = config::getConfigurations();
+					docOut["jsonrpc"] = jsonRpcVersion;
+					docOut["id"] = id;
+					docOut["result"] = configurations;
+					serializeJson(docOut, Serial);
+					Serial.println();
+				} else if (method == "setconfig") {
+					DynamicJsonDocument docOut(4096);
+					const JsonObject configurations = json["params"];
+					docOut["jsonrpc"] = jsonRpcVersion;
+					docOut["id"] = id;
+					docOut["result"] = config::saveConfigurations(configurations);
+					serializeJson(docOut, Serial);
+					Serial.println();
+				} else {
+					DynamicJsonDocument docOut(256);
+					docOut["jsonrpc"] = jsonRpcVersion;
+					docOut["id"] = id;
+					docOut["error"] = "Unknown method: \"" + method + "\"";
+					serializeJson(docOut, Serial);
+					Serial.println();
+				}
+			}
+		} catch (const std::exception &e) {
+			logger::write("JSON-RPC: " + std::string(e.what()), "error");
+		}
+	}
+}
+
+namespace jsonRpc {
+
+	void loop() {
+		if (!sentWaitingMessage) {
+			sentWaitingMessage = true;
+			logger::write("JSON-RPC serial interface now listening...");
+		}
+		if (!timedOut && !receivedMessage && micros() - bootTime > maxInitialMessageWaitTime) {
+			timedOut = true;
+			logger::write("Timed-out while waiting for initial JSON-RPC message");
+			delay(50);// Allow some time to finish writing the above log message.
+		}
+		if (jsonRpc::inUse()) {
+			if (Serial.available() > 0) {
+				onMessage(std::string(Serial.readStringUntil('\n').c_str()));
+			}
+		}
+	}
+
+	bool inUse() {
+		// Consider JSON-RPC interface to be "in-use" when either:
+		// A JSON-RPC message has been received or we are still waiting for an initial message.
+		return receivedMessage || !timedOut;
+	}
+}

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -17,8 +17,21 @@
 
 #include "logger.h"
 
-namespace logger {
-	void write(const std::string &msg) {
+namespace {
+
+	void writeToSerialMonitor(const std::string &msg) {
 		std::cout << msg << std::endl;
+	}
+}
+
+namespace logger {
+
+	void write(const std::string &t_msg, const std::string &t_type) {
+		const std::string msg = "[" + t_type + "] " + t_msg;
+		writeToSerialMonitor(msg);
+	}
+
+	void write(const std::string &t_msg) {
+		write(t_msg, "info");
 	}
 }

--- a/src/modules/button.cpp
+++ b/src/modules/button.cpp
@@ -27,6 +27,7 @@ namespace {
 namespace button {
 
 	void init() {
+		logger::write("Initializing button...");
 		pinMode(BUTTON_PIN, INPUT);
 	}
 

--- a/src/modules/dg600f.cpp
+++ b/src/modules/dg600f.cpp
@@ -19,6 +19,7 @@
 
 namespace {
 
+	bool initialized = false;
 	std::vector<float> coinValues;
 	float maxCoinValue = 0.00;
 	float accumulatedValue = 0.00;
@@ -71,19 +72,21 @@ namespace {
 
 namespace dg600f {
 
-	void init() {
-		coinValues = config::getCoinValues();
-		maxCoinValue = findMaxValueInFloatVector(coinValues);
-		Serial2.begin(COIN_ACCEPTOR_BAUDRATE, SERIAL_8E1, COIN_ACCEPTOR_SIGNAL, 0);
-		pinMode(COIN_ACCEPTOR_INHIBIT, OUTPUT);
-		dg600f::on();
-	}
+	void init() {}
 
 	void loop() {
+		if (!initialized) {
+			initialized = true;
+			logger::write("Initializing DG600F coin acceptor...");
+			coinValues = config::getCoinValues();
+			maxCoinValue = findMaxValueInFloatVector(coinValues);
+			Serial2.begin(COIN_ACCEPTOR_BAUDRATE, SERIAL_8E1, COIN_ACCEPTOR_SIGNAL, 0);
+			pinMode(COIN_ACCEPTOR_INHIBIT, OUTPUT);
+			dg600f::on();
+		}
 		while (Serial2.available()) {
 			const int byteReceived = Serial2.read();
 			if (byteReceived > 0 && byteReceived < 254) {
-				logger::write("Coin acceptor byte received: " + std::to_string(byteReceived));
 				buffer.push_back(byteReceived);
 			}
 		}

--- a/src/modules/hx616.cpp
+++ b/src/modules/hx616.cpp
@@ -19,6 +19,7 @@
 
 namespace {
 
+	bool initialized = false;
 	bool inhibited = false;
 	float valueIncrement = 1.00;
 	float accumulatedValue = 0.00;
@@ -47,13 +48,16 @@ namespace {
 
 namespace hx616 {
 
-	void init() {
-		pinMode(COIN_ACCEPTOR_SIGNAL, INPUT_PULLUP);
-		lastPinReadState = readPin();
-		valueIncrement = config::getCoinValueIncrement();
-	}
+	void init() {}
 
 	void loop() {
+		if (!initialized) {
+			initialized = true;
+			logger::write("Initializing HX616 coin acceptor...");
+			pinMode(COIN_ACCEPTOR_SIGNAL, INPUT_PULLUP);
+			lastPinReadState = readPin();
+			valueIncrement = config::getCoinValueIncrement();
+		}
 		if (pinStateHasChanged()) {
 			if (coinWasInserted()) {
 				// This code executes once for each pulse from the HX-616.

--- a/src/modules/tft.cpp
+++ b/src/modules/tft.cpp
@@ -135,7 +135,7 @@ namespace {
 namespace tft {
 
 	void init() {
-		logger::write("tft.init");
+		logger::write("Initializing TFT display...");
 		display.begin();
 		display.setRotation(config::getTftRotation());
 		clearScreen();

--- a/src/sdcard.cpp
+++ b/src/sdcard.cpp
@@ -73,6 +73,10 @@ namespace sdcard {
 		return std::string(mountpoint);
 	}
 
+	std::string getMountedPath(const std::string &partialPath) {
+		return std::string(mountpoint) + "/" + partialPath;
+	}
+
 	void init() {
 		if (mount()) {
 			logger::write("SD card mounted");


### PR DESCRIPTION
Adds a JSON-RPC via serial interface so that it is possible to reconfigure the device via WebSerial.

Use Non-volatile storage (NVS) to save configurations

Firmware name, version, commit hash

Use UART1 pins for coin acceptor