### PR TITLE
Fix QR code too small when text_size increased

### DIFF
--- a/src/screen/tft.cpp
+++ b/src/screen/tft.cpp
@@ -35,7 +35,7 @@ namespace {
 		display.setTextFont(text_font);
 		display.setTextSize(text_size);
 		int16_t tbw = display.textWidth(text);
-		int16_t tbh = display.fontHeight() * text_size;
+		int16_t tbh = display.fontHeight(); // no need to multiply by text_size because TFT_eSPI does this automatically after setTextSize() is called
 		int16_t box_x = x;
 		int16_t box_y = y;
 		if (center) {


### PR DESCRIPTION
The QR code was too small when the text_size was increased because the text's BoundingBox.h(eight) was too high, because it was being scaled twice.

The TFT_eSPI library scales the value returned by fontHeight() after setTextSize() has been called so there's no need to do that again.

See for example: https://github.com/Bodmer/TFT_eSPI/issues/78