### PR TITLE
Add support for the HX616 coin inhibit functionality

### DIFF
--- a/include/coin-acceptor/hx616.h
+++ b/include/coin-acceptor/hx616.h
@@ -10,6 +10,8 @@ namespace coinAcceptor_hx616 {
 	void loop();
 	float getAccumulatedValue();
 	void resetAccumulatedValue();
+	void inhibit();
+	void disinhibit();
 }
 
 #endif

--- a/src/coin-acceptor.cpp
+++ b/src/coin-acceptor.cpp
@@ -49,7 +49,7 @@ namespace coinAcceptor {
 	void inhibit() {
 		logger::write("Inhibiting coin acceptor");
 		if (coinAcceptorType == "hx616") {
-			// inhibit() not implemented for HX616
+			coinAcceptor_hx616::inhibit();
 		} else if (coinAcceptorType == "dg600f") {
 			coinAcceptor_dg600f::inhibit();
 		}
@@ -59,7 +59,7 @@ namespace coinAcceptor {
 	void disinhibit() {
 		logger::write("Disinhibiting coin acceptor");
 		if (coinAcceptorType == "hx616") {
-			// disinhibit() not implemented for HX616
+			coinAcceptor_hx616::disinhibit();
 		} else if (coinAcceptorType == "dg600f") {
 			coinAcceptor_dg600f::disinhibit();
 		}

--- a/src/coin-acceptor/hx616.cpp
+++ b/src/coin-acceptor/hx616.cpp
@@ -11,6 +11,7 @@ namespace {
 
 	float valueIncrement = 1.00;
 	uint16_t numPulses = 0;
+	unsigned short coinInhibitPin;
 	unsigned short coinSignalPin;
 
 	uint8_t minPulseTime = 20;// milliseconds
@@ -34,6 +35,7 @@ namespace coinAcceptor_hx616 {
 
 	void init() {
 		coinSignalPin = config::getUnsignedShort("coinSignalPin");
+		coinInhibitPin = config::getUnsignedShort("coinInhibitPin");
 		valueIncrement = config::getFloat("coinValueIncrement");
 	}
 
@@ -42,11 +44,16 @@ namespace coinAcceptor_hx616 {
 			if (!(coinSignalPin > 0)) {
 				logger::write("Cannot initialize coin acceptor: \"coinSignalPin\" not set", "warn");
 				state = State::failed;
+			} else if (coinInhibitPin > 0) {
+				// Only initialize if coinInhibitPin is set.
+				// Otherwise, don't fail, because it's optional.
+				pinMode(coinInhibitPin, OUTPUT);
 			} else {
 				logger::write("Initializing HX616 coin acceptor...");
 				pinMode(coinSignalPin, INPUT_PULLUP);
 				attachInterrupt(coinSignalPin, onPinStateChange, CHANGE);
 				state = State::initialized;
+				coinAcceptor_hx616::disinhibit();
 			}
 		}
 	}
@@ -58,4 +65,21 @@ namespace coinAcceptor_hx616 {
 	void resetAccumulatedValue() {
 		numPulses = 0;
 	}
+
+	void inhibit() {
+                if (state == State::initialized && coinInhibitPin > 0) {
+			digitalWrite(coinInhibitPin, LOW);
+		} else {
+			logger::write("Not inhibiting coin acceptor because state is not initialized or coinInhibitPin is not set.", "warn");
+                }
+        }
+
+        void disinhibit() {
+                if (state == State::initialized && coinInhibitPin > 0) {
+			digitalWrite(coinInhibitPin, HIGH);
+		} else {
+			logger::write("Not disinhibiting coin acceptor because state is not initialized or coinInhibitPin is not set.", "warn");
+		}
+        }
+
 }


### PR DESCRIPTION
There is very little documentation on the HX616 coin inhibit behavior, but from experimentation:
- if the HX616 coin inhibit pin is connected to ground (0V), then coins are refused
- if it's connected to more than 4V or is left floating, then coins are accepted
- if it's connected to 3V3 then coins are sometimes accepted, sometimes refused, so that's unreliable

One way to implement this is by connecting the ESP32's coinInhibit output pin to a low level trigger relay. The relay drives the connection between the HX616 coin inhibit wire and ground in "NO" (normally open) mode.

So when the ESP32 sets the coinInhibit output pin to LOW, the relay becomes active and connects the HX616 coin inhibit wire to ground, and coins are refused. And when the ESP32 sets coinInhibit output pin to HIGH, the relay becomes inactive and the HX616 coin inhibit wire is left floating, so coins are accepted.

It is probably also possible to implement the same relay/switch behavior using a MOSFET or transistor.