### PR TITLE
HX616 coin inhibit proper

### DIFF
--- a/include/coin-acceptor/hx616.h
+++ b/include/coin-acceptor/hx616.h
@@ -10,6 +10,8 @@ namespace coinAcceptor_hx616 {
 	void loop();
 	float getAccumulatedValue();
 	void resetAccumulatedValue();
+	void inhibit();
+	void disinhibit();
 }
 
 #endif

--- a/src/coin-acceptor.cpp
+++ b/src/coin-acceptor.cpp
@@ -49,7 +49,7 @@ namespace coinAcceptor {
 	void inhibit() {
 		logger::write("Inhibiting coin acceptor");
 		if (coinAcceptorType == "hx616") {
-			// inhibit() not implemented for HX616
+			coinAcceptor_hx616::inhibit();
 		} else if (coinAcceptorType == "dg600f") {
 			coinAcceptor_dg600f::inhibit();
 		}
@@ -59,7 +59,7 @@ namespace coinAcceptor {
 	void disinhibit() {
 		logger::write("Disinhibiting coin acceptor");
 		if (coinAcceptorType == "hx616") {
-			// disinhibit() not implemented for HX616
+			coinAcceptor_hx616::disinhibit();
 		} else if (coinAcceptorType == "dg600f") {
 			coinAcceptor_dg600f::disinhibit();
 		}


### PR DESCRIPTION
The coin inhibit of the HX 616 is the bottom pin header with 2 pins, labelled "SET" on my device. Of those 2 pins, the botton one is ground and the top is the coin inhibit pin.

The manual describes it as: "_Signal of forbidden energy inputting. Up PIN means signal inputting, voltage is more than 4V means OK, 0V means forbidden. Down PIN means ground wire._"

The above translation is hard to understand but experimentation shows that:
- if the HX616 coin inhibit pin is connected to ground (0V), then coins are refused
- if it's connected to more than 4V or is left floating, then coins are accepted
- if it's connected to 3V3 then coins are sometimes accepted, sometimes refused, so that's unreliable

The way I implemented this is by connecting the ESP32's coinInhibit output pin to a low level trigger relay. The relay drives the connection between the HX616 coin inhibit wire and ground in "NO" (normally open) mode.

So when the ESP32 sets the coinInhibit output pin to LOW, the relay becomes active and connects the HX616 coin inhibit wire to ground, and coins are refused. And when the ESP32 sets coinInhibit output pin to HIGH, the relay becomes inactive and the HX616 coin inhibit wire is left floating, so coins are accepted.

It might be possible to implement this in a different way, for example by using a MOSFET or transistor as a switch, or perhaps by using a 3V3 to 5V level converter or some kind of step-up/boost converter.